### PR TITLE
Parsers use 'parse_expr' function instead of 'simplify'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib~=3.5.1
-sympy~=1.9
+sympy==1.10
 telegram~=0.0.1
 python-telegram-bot~=13.10
 pytest~=6.2.5

--- a/source/core/handling_msg.py
+++ b/source/core/handling_msg.py
@@ -16,6 +16,7 @@ from source.extras.utilities import run_asynchronously
 from source.math.calculus_parser import CalculusParser
 from source.math.graph import Graph, DrawError
 from source.math.graph_parser import GraphParser, ParseError
+from source.math.math_function import MathError
 
 # We get "USE_LATEX" parameter from settings
 SETTINGS = Config()
@@ -154,10 +155,13 @@ async def send_analyse(message: types.Message):
     except ParseError as err:
         await message.reply(str(err))
         logger.info("ParseError exception raised on user's [chat_id=%s] input: `%s`", chat_id, expr)
+    except MathError as err:
+        await message.reply(str(err))
+        logger.info("MathError exception raised on user's [chat_id=%s] input: `%s`", chat_id, expr)
     except RecursionError:
         await message.reply("Incorrect input. Please check your function.")
         logger.warning("RecursionError exception raised on user's [chat_id=%s] input: `%s`", chat_id, expr)
-    except (ValueError, TypeError, NotImplementedError):
+    except (ValueError, TypeError, AttributeError, NotImplementedError):
         await message.reply("Sorry, can't solve the problem or the input is invalid. Please check your function.")
         logger.warning("ValueError or NotImplementedError exception raised on user's [chat_id=%s] input: `%s`", chat_id,
                        expr)

--- a/source/math/analyse_patterns.json
+++ b/source/math/analyse_patterns.json
@@ -5,7 +5,7 @@
         "6",
         "7"
       ],
-      "^(differentiate|diff|derivative)[ ]+(of[ ]+)?((a|the)[ ]+)?(function[ ]+)?(?!by)(.+)$": [
+      "^(differentiate|diff|derivative)[ ]+(of[ ]+)?((a|the)[ ]+)?(function[ ]+)?(.+)(?!by)$": [
         "6"
       ]
     },

--- a/source/math/graph_parser.py
+++ b/source/math/graph_parser.py
@@ -2,9 +2,11 @@
 Parser for graph requests
 """
 import re
+from tokenize import TokenError
 
 import sympy as sy
 from sympy import SympifyError
+from sympy.parsing.sympy_parser import convert_xor, implicit_multiplication_application, standard_transformations
 
 from source.conf import Config
 from source.extras.utilities import run_asynchronously
@@ -182,9 +184,10 @@ class GraphParser(Parser):
         token = replace_incorrect_functions(token)
         expr_parts = token.split('=')
         parts_count = len(expr_parts)
+        rules = standard_transformations + (implicit_multiplication_application, convert_xor)
         try:
             if parts_count == 1:
-                function = sy.simplify(expr_parts[0])
+                function = sy.parse_expr(expr_parts[0], transformations=rules)
 
                 # If there is only 'y' variable, then we can't understand what we should draw, because it is impossible
                 # to change axes in plot in our case
@@ -194,7 +197,8 @@ class GraphParser(Parser):
                                      f"Please, use 'x' instead of single 'y' variable for f(x) plot.")
             elif parts_count == 2:
                 # If parsed result always true or false (e.g. it is not a function at all)
-                result = sy.Eq(sy.simplify(expr_parts[0]), sy.simplify(expr_parts[1]))
+                result = sy.Eq(sy.parse_expr(expr_parts[0], transformations=rules),
+                               sy.parse_expr(expr_parts[1], transformations=rules))
 
                 # Check if number of variables is less than 2
                 if len(result.free_symbols) > 2:
@@ -212,10 +216,10 @@ class GraphParser(Parser):
                 vars_intersection = result.lhs.free_symbols & result.rhs.free_symbols
                 if re.match("^y$", expr_parts[0].strip()) is not None and len(vars_intersection) == 0:
                     modified_expr = expr_parts[1]
-                    function = sy.simplify(modified_expr)
+                    function = sy.parse_expr(modified_expr, transformations=rules)
                 else:
                     modified_expr = f"{expr_parts[0]} - ({expr_parts[1]})"
-                    function = sy.Eq(sy.simplify(modified_expr), 0)
+                    function = sy.Eq(sy.parse_expr(modified_expr, transformations=rules), 0)
 
             else:
                 raise ParseError("Mistake in implicit function: Found more than 1 equal sign.\n"
@@ -224,11 +228,11 @@ class GraphParser(Parser):
 
             # Change variables
             function = self._process_variables(function)
-
-            return function
-        except (SympifyError, TypeError, ValueError, SyntaxError, AttributeError) as err:
+        except (SympifyError, TypeError, ValueError, AttributeError, TokenError, SyntaxError) as err:
             raise ParseError(f"Mistake in expression.\nYour input: {token.strip()}\n"
                              "Please, check your math formula.") from err
+
+        return function
 
     @run_asynchronously
     def parse(self, expr: str):

--- a/source/math/math_function.py
+++ b/source/math/math_function.py
@@ -36,6 +36,10 @@ def replace_incorrect_functions(function: str) -> str:
     return result
 
 
+class MathError(Exception):
+    """Special exception for custom mathematical errors handling"""
+
+
 class MathFunction:
     """
     This class represents a plot of function
@@ -48,7 +52,7 @@ class MathFunction:
     :param symbols: a list of math expression variables
     """
 
-    def __init__(self, expression: str, simplified_expr: (sy.Function | sy.Equality), func_type: str = "explicit",
+    def __init__(self, expression: str, simplified_expr: (sy.Expr | sy.Eq), func_type: str = "explicit",
                  symbols: list = None):
         if symbols is None:
             symbols = []
@@ -75,9 +79,9 @@ class MathFunction:
                 for symbol in symbols:
                     diff_function = sy.diff(diff_function, symbol)
         except ValueError as err:
-            raise ValueError(f"Since there is more than one variable in the expression, "
-                             f"the variable(s) of differentiation must be supplied to "
-                             f"differentiate:\n{self.expression}") from err
+            raise MathError(f"Since there is more than one variable in the expression, "
+                            f"the variable(s) of differentiation must be supplied to "
+                            f"differentiate:\n{self.expression}") from err
 
         return diff_function
 
@@ -131,7 +135,12 @@ class MathFunction:
         :param symbol: see 'periodicity' arguments
         :return: see return of the 'periodicity' function
         """
-        return calculus.periodicity(self.simplified_expr, symbol)
+        result = calculus.periodicity(self.simplified_expr, symbol)
+        if result is None:
+            result = "Aperiodic function"
+        if result == 0:
+            result = "Function is constant (any period)"
+        return result
 
     def convexity(self, symbol: sy.Symbol) -> bool:
         """
@@ -220,7 +229,7 @@ class MathFunction:
                         ans.add(cur)
 
         # If function is periodic, we can't yet give an accurate answer
-        if self.periodicity(symbol):
+        if calculus.periodicity(self.simplified_expr, symbol):
             # If the domain of function is some kind of "R \ {...}", than we can omit the part "R \"
             if isinstance(exist, sy.Complement):
                 ans.add(exist.args[1])

--- a/source/math/parser.py
+++ b/source/math/parser.py
@@ -6,6 +6,7 @@ import re
 from abc import ABC, abstractmethod
 
 import sympy as sy
+from sympy.parsing.sympy_parser import convert_xor, implicit_multiplication_application, standard_transformations
 
 
 class ParseError(Exception):
@@ -37,9 +38,10 @@ class Parser(ABC):
         y = sy.Symbol('y')
         result = False
         parts = token.split('=')
+        rules = standard_transformations + (implicit_multiplication_application, convert_xor)
         if len(parts) == 2:
-            first_part = sy.simplify(parts[0])
-            second_part = sy.simplify(parts[1])
+            first_part = sy.parse_expr(parts[0], transformations=rules)
+            second_part = sy.parse_expr(parts[1], transformations=rules)
             symbols = first_part.free_symbols | second_part.free_symbols
             result = len(symbols) == 1 and symbols != {y}
 

--- a/tests/test_calculus_parser.py
+++ b/tests/test_calculus_parser.py
@@ -9,6 +9,7 @@ from source.math.parser import ParseError
 
 
 @pytest.mark.parametrize('expr, result', [('dif x+2', True),
+                                          ('diff y = x', True),
                                           ('[kw w', False),
                                           ('doman sin(x)+2', True),
                                           ('rang x**2+4', True),
@@ -32,9 +33,9 @@ async def test_parse_success(expr, result):
     assert await parser.CalculusParser.parse(parser.CalculusParser(), expr) == result
 
 
-@pytest.mark.parametrize("expr, exception", [('diff x1', ParseError),
-                                             ('domain 241+x6', ParseError),
-                                             ('concat dw10d1-', ParseError)])
+@pytest.mark.parametrize("expr, exception", [('diff [', ParseError),
+                                             ('diff [1]', AttributeError),
+                                             ('diff y=', ParseError)])
 @pytest.mark.asyncio
 async def test_parse_error(expr, exception):
     with pytest.raises(exception):

--- a/tests/test_graph_parser.py
+++ b/tests/test_graph_parser.py
@@ -20,12 +20,12 @@ def test_is_x_equal_num_expression(token, result):
 
 @pytest.mark.parametrize("expression, result", [("x, y, z, w, e, r, t, y, u, i, o, p, a, s, d, f, g, h", ParseError),
                                                 ("3y", ParseError),
-                                                ("y = 10sin(x)", ParseError),
                                                 ("y=x=z", ParseError),
                                                 ("y=4*x, from a to b", ParseError),
                                                 ("y=4*x+3*z", ParseError),
                                                 ("y=2+x, from 6 to 1", ParseError),
-                                                ("x^2, from ", ParseError)])
+                                                ("x^2, from ", ParseError),
+                                                ("y =", ParseError)])
 @pytest.mark.asyncio
 async def test_parse(expression, result):
     with pytest.raises(result):

--- a/tests/test_math_function.py
+++ b/tests/test_math_function.py
@@ -4,6 +4,7 @@ Tests for math functions
 
 import pytest
 import sympy as sy
+from sympy import Eq
 from sympy.abc import x, y
 
 import source.math.math_function as math_f
@@ -35,8 +36,9 @@ def test_derivative(expr, result):
     assert expr.derivative() == result
 
 
-@pytest.mark.parametrize("expression, result", [(MathFunction("", x + y), ValueError),
-                                                (MathFunction("", y ** x - 2), ValueError)])
+@pytest.mark.parametrize("expression, result", [(MathFunction("", x + y), math_f.MathError),
+                                                (MathFunction("", y ** x - 2), math_f.MathError),
+                                                (MathFunction("", Eq(y ** 2, x)), math_f.MathError)])
 def test_derivative_exceptions(expression, result):
     with pytest.raises(result):
         expression.derivative()
@@ -137,14 +139,15 @@ def test_frange(expr, result):
     assert expr.frange(*expr.symbols) == result
 
 
-@pytest.mark.parametrize("expr, result", [(MathFunction("", x, symbols=[x]), None),
+@pytest.mark.parametrize("expr, result", [(MathFunction("", x, symbols=[x]), "Aperiodic function"),
                                           (MathFunction("", sy.sin(x), symbols=[x]), sy.pi * 2),
                                           (MathFunction("", sy.tan(x), symbols=[x]), sy.pi),
-                                          (MathFunction("", sy.atan(x), symbols=[x]), None),
-                                          (MathFunction("", sy.sin(x) * x, symbols=[x]), None),
+                                          (MathFunction("", sy.atan(x), symbols=[x]), "Aperiodic function"),
+                                          (MathFunction("", sy.sin(x) * x, symbols=[x]), "Aperiodic function"),
                                           (MathFunction("", sy.log(sy.sin(x)), symbols=[x]), sy.pi * 2),
                                           (MathFunction("", sy.sqrt((sy.sin(x)) ** 2), symbols=[x]), sy.pi),
-                                          (MathFunction("", 13 * x ** 0, symbols=[x]), 0)])
+                                          (MathFunction("", 13 * x ** 0, symbols=[x]),
+                                           "Function is constant (any period)")])
 def test_periodicity(expr, result):
     assert expr.periodicity(*expr.symbols) == result
 


### PR DESCRIPTION
New parsing method via 'parse_expr' Sympy function

- **Main features:**
  - 'parse_expr' instead of 'simplify' in '_process_function' functions (in both parsers)
- **Bugfixes:**
  - Fix tests for 'parse_expr'
  - Fix: pattern 'diff * by *' sometimes triggered falsely (change pattern)
  - Fix: some exceptions are not handled (TokenError in case "diff [", AttributeError in case "diff [1]" and SyntaxError)
- **Others:**
  - Update Sympy to 1.10
  - Add MathError exception class for some obvious math errors (e.g. several equals in expression)
  - Add some tests for unhandled exceptions