### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Project
+.idea/
+.github/
+.*ignore
+README.md
+CONTRIBUTING.md
+.pylintrc
+/resources
+
+
+# Cache
+*.py[cod]
+__pycache__
+
+
+# Docker
+docker-compose*.yml
+Dockerfile


### PR DESCRIPTION
.dockerignore doesn't copy unnecessary files in working directory speeding up the deployment